### PR TITLE
Issue9 static variables

### DIFF
--- a/midas2root/Makefile
+++ b/midas2root/Makefile
@@ -59,7 +59,7 @@ endif # MIDASSYS
 
 OBJS:= TTreeMaker.o TBRBRawData.o
 
-all: $(OBJS)  midas2root_ptf.exe midas2root_mpmt.exe
+all: $(OBJS)  midas2root_ptf.exe midas2root_mpmt.exe eventDisplay.exe
 
 midas2root_ptf.exe: midas2root_ptf.cxx $(OBJS) 
 	$(CXX) -o $@ $(CXXFLAGS) $^ $(LIBS) $(ROOTGLIBS) -lm -lz -lpthread -lssl -lutil
@@ -67,6 +67,8 @@ midas2root_ptf.exe: midas2root_ptf.cxx $(OBJS)
 midas2root_mpmt.exe: midas2root_mpmt.cxx $(OBJS) 
 	$(CXX) -o $@ $(CXXFLAGS) $^ $(LIBS) $(ROOTGLIBS) -lm -lz -lpthread -lssl -lutil
 
+eventDisplay.exe: eventDisplay.cpp $(OBJS)
+	$(CXX) -o $@ $(CXXFLAGS) $^ $(LIBS) $(ROOTGLIBS) -lm -lz -lpthread -lssl -lutil
 
 %.o: %.cxx
 	$(CXX) -o $@ $(CXXFLAGS) -c $<

--- a/midas2root/eventDisplay.cpp
+++ b/midas2root/eventDisplay.cpp
@@ -1,0 +1,172 @@
+#include <stdio.h>
+#include <iostream>
+#include "TCanvas.h"
+#include "TH2D.h"
+#include "TH1.h"
+#include "TPad.h"
+#include "TFile.h"
+#include "TTree.h"
+#include "TLegend.h"
+#include "TApplication.h"
+
+// CHANGE THIS ACCORDING TO DIGITIZER USED.
+#define PMT_CHANNEL_FORMAT "V1730_wave%i"
+#define mPMT_DIGITIZER_SAMPLE_RATE 125 // MS/s
+#define mPMT_DIGITIZER_FULL_SCALE_RANGE 2.0 // Vpp
+#define mPMT_DIGITIZER_RESOLUTION 12 // bits
+
+
+int main(int argc, char** argv) {
+
+    std::cout<<argc<<std::endl;
+
+    // Start the function to display the event.
+    int eventEntry = atoi(argv[2]);
+
+    // Is this entry valid? Set to false by default.
+    bool validEntry = false;
+
+    // Defining global variables:
+    auto scanTree = new TTree();
+    int numTimeBins = 1024;
+    float timeFactor = 8.0; // ns
+    Double_t digiCounts = pow(2.0, mPMT_DIGITIZER_RESOLUTION); // counts ?
+    Double_t scaleFactor = mPMT_DIGITIZER_FULL_SCALE_RANGE/digiCounts; // V/counts ?
+
+    // Test arguments passed through from terminal:
+    if (argc!=3) {
+
+        // Tell the user how to use the root file.
+        std::cout << std::endl << "eventDisplay.exe usage:" <<std::endl;
+        std::cout << "Provide path to root file and no. of event to be viewed."<<std::endl;
+        std::cout << "Example: ./midas2root_mpmt.exe ./output00000400.root 1500"<<std::endl;
+    
+    } else {
+
+
+        // Open root file:
+        auto rootFile = new TFile(argv[1], "READ");
+
+        // Tree name:
+        char waveformTreeName[1024] = "scan_tree";
+
+        // Retrieve the tree from the file:
+        std::cout<<"Opening up root file..."<<std::endl;
+        
+        rootFile->GetObject(waveformTreeName, scanTree);
+
+        // Getting number of entries:
+        int numEntries = scanTree->GetEntries();
+        std::cout<<"No. of entries found: "<<numEntries<<"."<<std::endl;
+
+        // Testing initial entry:
+        if (eventEntry < 0 || eventEntry > numEntries) {
+            std::cout<<"Invalid event number."<<std::endl;
+        } else {
+            std::cout<<"Event in display: "<<eventEntry<<"."<<std::endl;
+            validEntry = true;
+        }
+    }
+
+    if (validEntry) {
+
+        // Root app, to show the canvas.
+
+        // NOTICE: TApplication is not compatible with 
+        // argv[1] being a char, so do not move this declaration
+        // to before the rootfile is open.
+        auto theApp = new TApplication("App", &argc, argv);
+        
+        // Getting waveform parameters from the tree
+        int num_points;
+        auto dataBranch = scanTree->GetBranch("num_points");
+        dataBranch->SetAddress(&num_points);
+        scanTree->GetEntry(0);
+    
+        // Defining matrices to hold the waveform informations:
+        Double_t V1730_wave0[num_points][numTimeBins], V1730_wave1[num_points][numTimeBins], V1730_wave2[num_points][numTimeBins], V1730_wave3[num_points][numTimeBins];
+
+        // Open up the waveform branches.
+        // NOTICE: Only 4 channels' data are being retrieved 
+        // for the time being. Add the additional branch addresses here
+        // in the future. 
+        auto dataBranch0 = scanTree->GetBranch("V1730_wave0");
+        auto dataBranch1 = scanTree->GetBranch("V1730_wave1");
+        auto dataBranch2 = scanTree->GetBranch("V1730_wave2");
+        auto dataBranch3 = scanTree->GetBranch("V1730_wave3");
+
+        // Store the information from the branches 
+        // into the matrices defined above
+        dataBranch0->SetAddress(&V1730_wave0);
+        dataBranch1->SetAddress(&V1730_wave1);
+        dataBranch2->SetAddress(&V1730_wave2);
+        dataBranch3->SetAddress(&V1730_wave3);
+
+        // Access the data
+        scanTree->GetEntry(eventEntry);
+
+        // Defining histograms and canvas to be shown
+        auto canvas = new TCanvas("c1","",900,900);
+        auto hwaveform0 = new TH1F("waveform0","Channel 0; Time(ns); Voltage (V)", numTimeBins, 0.0, float(numTimeBins)*1000./mPMT_DIGITIZER_SAMPLE_RATE);
+        auto hwaveform1 = new TH1D("waveform1","Channel 1; Time(ns); Voltage (V)", numTimeBins, 0.0, float(numTimeBins)*1000./mPMT_DIGITIZER_SAMPLE_RATE);
+        auto hwaveform2 = new TH1D("waveform2","Channel 2; Time(ns); Voltage (V)", numTimeBins, 0.0, float(numTimeBins)*1000./mPMT_DIGITIZER_SAMPLE_RATE);
+        auto hwaveform3 = new TH1D("waveform3","Channel 3; Time(ns); Voltage (V)", numTimeBins, 0.0, float(numTimeBins)*1000./mPMT_DIGITIZER_SAMPLE_RATE);
+
+        // Filling in the histograms
+        for (int k=1; k<1024; k++) {
+
+            // Changing the horizontal axis to ns
+            Double_t time = float(k)*timeFactor;
+
+            // Filling in the histograms with data
+            hwaveform0->Fill(time, float(V1730_wave0[0][k-1]));
+            hwaveform1->Fill(time, float(V1730_wave1[0][k-1]));
+            hwaveform2->Fill(time, float(V1730_wave2[0][k-1]));
+            hwaveform3->Fill(time, float(V1730_wave3[0][k-1]));
+
+        }
+
+        // Change vertical scale from counts to volts
+        hwaveform0->Scale(scaleFactor);
+        hwaveform1->Scale(scaleFactor);
+        hwaveform2->Scale(scaleFactor);
+        hwaveform3->Scale(scaleFactor);
+
+        // Changing the style of the histograms
+        hwaveform0->SetLineWidth(2);
+        hwaveform0->SetLineColor(1);
+        hwaveform0->SetStats(0);
+
+        hwaveform1->SetLineWidth(2);
+        hwaveform1->SetLineColor(1);
+        hwaveform1->SetStats(0);
+
+        hwaveform2->SetLineWidth(2);
+        hwaveform2->SetLineColor(1);
+        hwaveform2->SetStats(0);
+
+        hwaveform3->SetLineWidth(2);
+        hwaveform3->SetLineColor(1);
+        hwaveform3->SetStats(0);
+
+        // Dividing canvas.
+        canvas->Divide(4,5);
+
+        // Drawing histograms.
+        canvas->cd(1);
+        hwaveform0->Draw("HIST");
+        canvas->cd(2);
+        hwaveform1->Draw("HIST");
+        canvas->cd(3);
+        hwaveform2->Draw("HIST");
+        canvas->cd(4);
+        hwaveform3->Draw("HIST");
+
+        // Show canvas
+        theApp->Run();
+        
+    }
+
+    // End of function.
+    return 0;
+}

--- a/midas2root/midas2root_mpmt.cxx
+++ b/midas2root/midas2root_mpmt.cxx
@@ -123,7 +123,7 @@ class ScanToTreeConverter: public TRootanaEventLoop {
   ScanToTreeConverter() {
     UseBatchMode(); //necessary to switch off graphics, used in for example AnaDisplay
     nnn = 0;
-    fNChan = 2;
+    fNChan = 4;
   };
 
   virtual ~ScanToTreeConverter() {};
@@ -387,6 +387,8 @@ class ScanToTreeConverter: public TRootanaEventLoop {
           for(int ib = 0; ib < measures[i].GetNSamples(); ib++){
             if(chan == 0) V1730_wave0[num_points-1][ib] = measures[i].GetSample(ib);  
             if(chan == 1) V1730_wave1[num_points-1][ib] = measures[i].GetSample(ib);  
+            if(chan == 2) V1730_wave2[num_points-1][ib] = measures[i].GetSample(ib);  
+            if(chan == 3) V1730_wave3[num_points-1][ib] = measures[i].GetSample(ib);  
           }              
         }	      
         

--- a/midas2root/midas2root_mpmt.cxx
+++ b/midas2root/midas2root_mpmt.cxx
@@ -296,9 +296,13 @@ class ScanToTreeConverter: public TRootanaEventLoop {
     StartVal0->SetDirectory(0);
 
     ngoodTDCbanks = 0;
-    nbadTDCbanks = 0; 
+    nbadTDCbanks = 0;
+    
 
     // Fill a settings tree using information from ODB
+#ifdef INCLUDE_MVODB_H
+    std::cout << "Filling Setting TTree " << std::endl;
+
     MVOdb* odb = GetODB();
     TTree *settings_tree = new TTree("settings_tree","Settings Tree");
 
@@ -344,6 +348,7 @@ class ScanToTreeConverter: public TRootanaEventLoop {
     }
 
     settings_tree->Fill();
+#endif  // Done ifdef settings ttree filling
 
 
   }

--- a/midas2root/midas2root_mpmt.cxx
+++ b/midas2root/midas2root_mpmt.cxx
@@ -123,7 +123,7 @@ class ScanToTreeConverter: public TRootanaEventLoop {
   ScanToTreeConverter() {
     UseBatchMode(); //necessary to switch off graphics, used in for example AnaDisplay
     nnn = 0;
-    fNChan = 4;
+    fNChan = 19; // < Saving waveforms from 0 to 19
   };
 
   virtual ~ScanToTreeConverter() {};
@@ -388,7 +388,23 @@ class ScanToTreeConverter: public TRootanaEventLoop {
             if(chan == 0) V1730_wave0[num_points-1][ib] = measures[i].GetSample(ib);  
             if(chan == 1) V1730_wave1[num_points-1][ib] = measures[i].GetSample(ib);  
             if(chan == 2) V1730_wave2[num_points-1][ib] = measures[i].GetSample(ib);  
-            if(chan == 3) V1730_wave3[num_points-1][ib] = measures[i].GetSample(ib);  
+            if(chan == 3) V1730_wave3[num_points-1][ib] = measures[i].GetSample(ib);
+            if(chan == 4) V1730_wave4[num_points-1][ib] = measures[i].GetSample(ib);
+            if(chan == 5) V1730_wave5[num_points-1][ib] = measures[i].GetSample(ib);
+            if(chan == 6) V1730_wave6[num_points-1][ib] = measures[i].GetSample(ib);
+            if(chan == 7) V1730_wave7[num_points-1][ib] = measures[i].GetSample(ib);
+            if(chan == 8) V1730_wave8[num_points-1][ib] = measures[i].GetSample(ib);
+            if(chan == 9) V1730_wave9[num_points-1][ib] = measures[i].GetSample(ib);
+            if(chan == 10) V1730_wave10[num_points-1][ib] = measures[i].GetSample(ib);
+            if(chan == 11) V1730_wave11[num_points-1][ib] = measures[i].GetSample(ib);
+            if(chan == 12) V1730_wave12[num_points-1][ib] = measures[i].GetSample(ib);
+            if(chan == 13) V1730_wave13[num_points-1][ib] = measures[i].GetSample(ib);
+            if(chan == 14) V1730_wave14[num_points-1][ib] = measures[i].GetSample(ib);
+            if(chan == 15) V1730_wave15[num_points-1][ib] = measures[i].GetSample(ib);
+            if(chan == 16) V1730_wave16[num_points-1][ib] = measures[i].GetSample(ib);
+            if(chan == 17) V1730_wave17[num_points-1][ib] = measures[i].GetSample(ib);
+            if(chan == 18) V1730_wave18[num_points-1][ib] = measures[i].GetSample(ib);
+            if(chan == 19) V1730_wave19[num_points-1][ib] = measures[i].GetSample(ib);
           }              
         }	      
         

--- a/midas2root/midas2root_mpmt.cxx
+++ b/midas2root/midas2root_mpmt.cxx
@@ -298,6 +298,21 @@ class ScanToTreeConverter: public TRootanaEventLoop {
     ngoodTDCbanks = 0;
     nbadTDCbanks = 0; 
 
+    // Fill a settings tree using information from ODB
+    MVOdb* odb = GetODB();
+    std::vector<int> hv;
+    //int hv;
+    odb->RIA("/Equipment/PMTS00/Settings/HVset",&hv);
+    //odb->RI("/Equipment/PMTS00/Statistics/Events sent",&hv);
+    std::cout << "HV set: " << hv[0] << " " << hv[1] << std::endl;
+
+    double rate;			       
+    int events;
+    //int hv;
+    odb->RD("/Equipment/BRB/Statistics/Events per sec.",&rate);
+    odb->RI("/Equipment/BRB/Statistics/Events sent",&events);
+    std::cout << "Check online/offline: " << rate << " " << events << std::endl;
+
   }
 
   void EndRun(int transition,int run,int time){


### PR DESCRIPTION
This implements a possible fix for storing static variables for the mPMT into the ROOT file.

I implemented it as a separate tree ("Settings Tree"), which only has one entry, which is filled in the begin of run method.  Currently I store the HV set points, the HV readback, the HV current and the calculated baseline.  I grab these values from the copy of the ODB which is encoded in the first event of the MIDAS file (in JSON format).

There is actually a problem with how I grab the data from this ODB JSON dump, but I am separately dealing with this bug in rootana.