### PR TITLE
Various fixes for `midas2root_ptf`

### DIFF
--- a/midas2root/Makefile
+++ b/midas2root/Makefile
@@ -2,7 +2,7 @@
 # Example Makefile for ROOTANA-based projects
 #
 
-CXXFLAGS = -g -O2 -Wall -Wuninitialized
+CXXFLAGS = -O2 -Wall -Wuninitialized
 
 # required ZLIB library
 
@@ -45,7 +45,8 @@ endif # ROOTSYS
 
 ifdef MIDASSYS
 
-MIDASLIBS = $(MIDASSYS)/linux/lib/libmidas.a -lutil -lrt
+MIDASLIBS = $(MIDASSYS)/lib/libmidas.a -lutil -lrt
+#MIDASLIBS = $(MIDASSYS)/lib/libmidas.a
 CXXFLAGS += -DHAVE_MIDAS -DOS_LINUX -Dextname -I$(MIDASSYS)/include
 
 UNAME := $(shell uname)

--- a/midas2root/README.md
+++ b/midas2root/README.md
@@ -1,0 +1,54 @@
+# Midas2Root: The PTF Version 
+
+This is a utility for converting a midas event stream into a root file for the PTF analyses. 
+It's a modification of the baseline midas2root code with a few fixes/improvements
+    - For scans which span multiple files, this code keeps track of whether or not events are being kept as we switch from one file to another
+    - No more segfaults! The TTree is always instantiated, so when a scan spans multiple files we don't try to TTree->Fill a null pointer 
+
+These fixes required pairing the c++ executable with a bash script to make sure the call is made properly. 
+
+The bash script keeps track of whether or not data is being kept (ie, if the gantry was moving) and tells 
+
+## Why did those segfaults happen? 
+
+**The Problem:** originally, the TTree was only made when at a "run start" midas event. 
+As a consequence, in files after the first, the TTree would never be made. 
+And so when the fill command was called we'd get a segfault.
+As an extra consequence, later files had no way to communicate the run number to midas2root.
+
+**The Fix:** now we now explicilty make the TTree if it's a null pointer.
+The run number is now also provided, by the bash script, as an argument to midas2root_ptf. 
+
+## How does it keep track of gantry motion? 
+
+**The Problem:** the midas2root event stream is interrupted at the end of a file and resumed at the next one. 
+Midas2root processes each file's event stream individually, after processing all files it then concatenates the individual files' root files into one big root file. 
+Midas2root can, upon starting to process a file's event stream, default to either *accept* or *reject* events (essentially this is assuming the gantry is starting *stationary* or *mid-move*). 
+
+Either assumption cannot be accurate in all cases. 
+If it defaults to accept, when midas switches between files mid-move then some scanpoint will end up with an excessive number of noisy non-sense waveforms. 
+If it instead defaults to reject, then when midas switches between files mid-scan then that scanpoint will be interrupted. 
+
+**The Fix:** now, when midas2root reaches the end of a file, the acceptance status is returned by the `main` method. The controlling bash script records this return value, and then passes it on as an argument to the next midas2root instance. 
+
+
+### Possible Better Fix:
+The current fix is hacky and leads to midas2root searching for the run number and the movement status as other files. 
+If your run number is "5660" and you have a similarly named file, this will lead to unexpected behavior and almost certainly a crash. 
+
+I don't know how easy this would be to implement, but there certainly are more robust fixes possible!
+But if midas could include a header event for each new file including the run number, that would be tremendously helpful. 
+If these header events could include more meta-information, that would be event better.
+
+An alternative, probably better fix, would be if the midas2root_ptf script could be fundamentally modified to process a series of files as a single event stream. 
+This functionality *does* appear to be in the event stream code, but it isn't incorporated with midas2root.
+
+# Usage 
+
+Create a symbolic link in your data folder that points to the `run_convert_to_root.sh` script. 
+In the data folder (ie `/home/midptf/online/data`), call 
+```
+   ./run_convert_to_root.sh <run number> 
+```
+
+Another template script for reprocessing multiple runs is included, `reprocess_data.sh`

--- a/midas2root/midas2root_ptf.cxx
+++ b/midas2root/midas2root_ptf.cxx
@@ -21,7 +21,7 @@
 #define num_phidg_max 10000
 #define max_temp_sensor 20
 #define num_v1730_max 70 // IMPOTANT: IF THIS IS EVER CHANGED, ALSO CHANGE THE HARDCODED VALUES FOR WAVEFORM BRANCH WIDTHS AS WELL (see: "v1730 data")
-#define timeStart 110 // defines start of PMT Pulse timing window, currently at the 130th sample of 200, with a window size of 70 samples.
+#define timeStart 110 // defines start of PMT Pulse timing window, currently at the 130th sample of 200, with a window size of 400 samples.
 
 // Offset for the ADC channel number
 #define Ch_Offset 1
@@ -160,11 +160,11 @@ class ScanToTreeConverter: public TRootanaEventLoop {
 
     // v1730 data  V1730_wave0[nPoints_max][num_v1730_max]
     tree->Branch("V1730_wave0",&V1730_wave0,"V1730_wave0[num_points][70]/D"); //think of eqn* // SIZE OF COLUMN MUST MATCH num_v1730_max OR ELSE BANDING ISSUES WILL OCCUR
-    tree->Branch("V1730_wave1",&V1730_wave1,"V1730_wave1[num_points][70]/D"); //think of eqn*
+    //tree->Branch("V1730_wave1",&V1730_wave1,"V1730_wave1[num_points][400]/D"); //think of eqn*
     tree->Branch("V1730_wave2",&V1730_wave2,"V1730_wave2[num_points][70]/D"); //think of eqn*
-    tree->Branch("V1730_wave3",&V1730_wave3,"V1730_wave3[num_points][70]/D"); 
-    tree->Branch("V1730_wave4",&V1730_wave4,"V1730_wave4[num_points][70]/D");
-    tree->Branch("V1730_wave5",&V1730_wave5,"V1730_wave5[num_points][70]/D");
+    //tree->Branch("V1730_wave3",&V1730_wave3,"V1730_wave3[num_points][400]/D"); 
+    //tree->Branch("V1730_wave4",&V1730_wave4,"V1730_wave4[num_points][400]/D");
+    //tree->Branch("V1730_wave5",&V1730_wave5,"V1730_wave5[num_points][400]/D");
     //tree->Branch("V1730_wave0",&V1730_wave0,"V1730_wave0[num_points]/D"); //think of eqn*
     //tree->Branch("V1730_wave1",&V1730_wave1,"V1730_wave1[num_points]/D"); //think of eqn*
     //tree->Branch("V1730_wave2",&V1730_wave2,"V1730_wave2[num_points]/D"); //think of eqn*
@@ -297,7 +297,7 @@ class ScanToTreeConverter: public TRootanaEventLoop {
 
   bool ProcessMidasEvent(TDataContainer& dataContainer){
     if (!tree){
-      initialize_tree(5611);
+      initialize_tree(5614);
     }
     
     TGenericData *bank = dataContainer.GetEventData<TGenericData>("EOM");  // END OF MOVE = START of MEASUREMENT
@@ -310,10 +310,7 @@ class ScanToTreeConverter: public TRootanaEventLoop {
     if(bank){
 	    timestamp=dataContainer.GetMidasData().GetTimeStamp();//this is where we fill the tree for the time
       tree->Fill();
-      std::cout << "Started move. gantry position counter:  " << counter_gant
-      << " position: " << x0_pos << " " << y0_pos << " " << z0_pos
-      << " number digi events " << num_points << std::endl;
-
+     
       counter = 0;
       num_points = 0;
       num_points_dig0 = 0;
@@ -363,7 +360,7 @@ class ScanToTreeConverter: public TRootanaEventLoop {
             if(chan < 0 || chan >5) continue; // 9.Nov.2017 updated for first 5 channels only
             //		  std::cout << "chan " << chan << std::endl;
             
-            // saves num_v1730_max (currently 70) bins around each pulse
+            // saves num_v1730_max (currently 400) bins around each pulse
             // laser pulse is given an offset as it occurs earlier in time
             // Note: 1 ib  = 2 ns
             // This is what writes Midas data to the ROOT tree
@@ -375,21 +372,18 @@ class ScanToTreeConverter: public TRootanaEventLoop {
             // 3          Gantry0 monitor PMT
             // 4          Gantry1 receiver PMT
             // 5          Gantry1 monitor PMT
+
+            //std::cout <<measurements[i].GetNSamples() << " samples "<<std::endl; 
             
             for(int ib = timeStart; ib < measurements[i].GetNSamples() && ib  < num_v1730_max + timeStart ; ib++){
               
               //std::cout<<"ib = " <<ib <<std::endl;
               
-              if(chan == 0){ 
-                  V1730_wave0[num_points-1][ib-timeStart] = measurements[i].GetSample(ib);
-		              if(measurements[i].GetSample(ib) < 7900){ 
-                    pmt_hit = true; std::cout << "PMT hit " << std::endl;
-		              }
-	            }
-              if(chan == 1) V1730_wave1[num_points-1][ib-timeStart] = measurements[i].GetSample(ib-timeStart); // -130 is the timeStart offset, meaning the reference signal window starts at the start of the digitizer readout
-              if(chan == 2) V1730_wave2[num_points-1][ib-timeStart] = measurements[i].GetSample(ib-timeStart);
-              if(chan == 3) V1730_wave3[num_points-1][ib-timeStart] = measurements[i].GetSample(ib-60); 
-              if(chan == 5) V1730_wave5[num_points-1][ib-timeStart] = measurements[i].GetSample(ib-60); 
+              if(chan == 0) V1730_wave0[num_points-1][ib-timeStart] = measurements[i].GetSample(ib+89);
+              //if(chan == 1) V1730_wave1[num_points-1][ib-timeStart] = measurements[i].GetSample(ib-timeStart); // -130 is the timeStart offset, meaning the reference signal window starts at the start of the digitizer readout
+              if(chan == 2) V1730_wave2[num_points-1][ib-timeStart] = measurements[i].GetSample(i+40);
+              //if(chan == 3) V1730_wave3[num_points-1][ib-timeStart] = measurements[i].GetSample(ib-60); 
+             // if(chan == 5) V1730_wave5[num_points-1][ib-timeStart] = measurements[i].GetSample(ib-60); 
             }		             	      
           }
         }else{

--- a/midas2root/midas2root_ptf.cxx
+++ b/midas2root/midas2root_ptf.cxx
@@ -20,8 +20,8 @@ constexpr int nPoints_max = single_point ? 1800*1600 : 12000; // if single_point
 
 const int num_phidg_max = 10000;
 const int max_temp_sensor = 20;
-const int num_v1730_max = 140; // IMPOTANT: IF THIS IS EVER CHANGED, ALSO CHANGE THE HARDCODED VALUES FOR WAVEFORM BRANCH WIDTHS AS WELL (see: "v1730 data")
-const int timeStart = 110; // defines start of PMT Pulse timing window, currently at the 130th sample of 200, with a window size of 400 samples.
+const int num_v1730_max = 70; // IMPOTANT: IF THIS IS EVER CHANGED, ALSO CHANGE THE HARDCODED VALUES FOR WAVEFORM BRANCH WIDTHS AS WELL (see: "v1730 data")
+const int timeStart = 180; // defines start of PMT Pulse timing window, currently at the 130th sample of 200, with a window size of 400 samples.
 
 // Offset for the ADC channel number
 const int Ch_Offset = 1;
@@ -163,12 +163,12 @@ class ScanToTreeConverter: public TRootanaEventLoop {
     tree->Branch("evt_timestamp",&evt_timestamp,"evt_timestamp[num_points]/D");
 
     // v1730 data  V1730_wave0[nPoints_max][num_v1730_max]
-    tree->Branch("V1730_wave0",&V1730_wave0,"V1730_wave0[num_points][140]/D"); //think of eqn* // SIZE OF COLUMN MUST MATCH num_v1730_max OR ELSE BANDING ISSUES WILL OCCUR
-    tree->Branch("V1730_wave1",&V1730_wave1,"V1730_wave1[num_points][140]/D"); //think of eqn*
-    tree->Branch("V1730_wave2",&V1730_wave2,"V1730_wave2[num_points][140]/D"); //think of eqn*
-    //tree->Branch("V1730_wave3",&V1730_wave3,"V1730_wave3[num_points][140]/D"); 
-    //tree->Branch("V1730_wave4",&V1730_wave4,"V1730_wave4[num_points][140]/D");
-    //tree->Branch("V1730_wave5",&V1730_wave5,"V1730_wave5[num_points][140]/D");
+    tree->Branch("V1730_wave0",&V1730_wave0,"V1730_wave0[num_points][70]/D"); //think of eqn* // SIZE OF COLUMN MUST MATCH num_v1730_max OR ELSE BANDING ISSUES WILL OCCUR
+    tree->Branch("V1730_wave1",&V1730_wave1,"V1730_wave1[num_points][70]/D"); //think of eqn*
+    tree->Branch("V1730_wave2",&V1730_wave2,"V1730_wave2[num_points][70]/D"); //think of eqn*
+    //tree->Branch("V1730_wave3",&V1730_wave3,"V1730_wave3[num_points][70]/D"); 
+    //tree->Branch("V1730_wave4",&V1730_wave4,"V1730_wave4[num_points][70]/D");
+    //tree->Branch("V1730_wave5",&V1730_wave5,"V1730_wave5[num_points][70]/D");
     //tree->Branch("V1730_wave0",&V1730_wave0,"V1730_wave0[num_points]/D"); //think of eqn*
     //tree->Branch("V1730_wave1",&V1730_wave1,"V1730_wave1[num_points]/D"); //think of eqn*
     //tree->Branch("V1730_wave2",&V1730_wave2,"V1730_wave2[num_points]/D"); //think of eqn*

--- a/midas2root/midas2root_ptf.cxx
+++ b/midas2root/midas2root_ptf.cxx
@@ -15,8 +15,8 @@
 #include <TFile.h>
 
 
-constexpr bool single_point = true; // set to true for non-scans. This makes it accept everything! 
-constexpr int nPoints_max = single_point ? 1800*1600 : 6000; // if single_point, we do an hour. otherwise, like 4 seconds of data
+constexpr bool single_point = false; // set to true for non-scans. This makes it accept everything! 
+constexpr int nPoints_max = single_point ? 1800*1600 : 12000; // if single_point, we do an hour. otherwise, like 4 seconds of data
 
 const int num_phidg_max = 10000;
 const int max_temp_sensor = 20;
@@ -98,6 +98,8 @@ class ScanToTreeConverter: public TRootanaEventLoop {
   // V1730 waveforms
   // 9.Nov.2017 Let's try adding using channels 2,3,4, 5
   double V1730_wave0[nPoints_max][num_v1730_max],V1730_wave1[nPoints_max][num_v1730_max], V1730_wave2[nPoints_max][num_v1730_max];
+  double V1730_wave3[nPoints_max][num_v1730_max],V1730_wave4[nPoints_max][num_v1730_max], V1730_wave5[nPoints_max][num_v1730_max];
+
 
   // Add a timestamp for each event. TL 2022-02-25 
   double evt_timestamp[nPoints_max];
@@ -162,11 +164,11 @@ class ScanToTreeConverter: public TRootanaEventLoop {
 
     // v1730 data  V1730_wave0[nPoints_max][num_v1730_max]
     tree->Branch("V1730_wave0",&V1730_wave0,"V1730_wave0[num_points][140]/D"); //think of eqn* // SIZE OF COLUMN MUST MATCH num_v1730_max OR ELSE BANDING ISSUES WILL OCCUR
-    tree->Branch("V1730_wave1",&V1730_wave1,"V1730_wave1[num_points][400]/D"); //think of eqn*
+    tree->Branch("V1730_wave1",&V1730_wave1,"V1730_wave1[num_points][140]/D"); //think of eqn*
     tree->Branch("V1730_wave2",&V1730_wave2,"V1730_wave2[num_points][140]/D"); //think of eqn*
-    //tree->Branch("V1730_wave3",&V1730_wave3,"V1730_wave3[num_points][400]/D"); 
-    //tree->Branch("V1730_wave4",&V1730_wave4,"V1730_wave4[num_points][400]/D");
-    //tree->Branch("V1730_wave5",&V1730_wave5,"V1730_wave5[num_points][400]/D");
+    //tree->Branch("V1730_wave3",&V1730_wave3,"V1730_wave3[num_points][140]/D"); 
+    //tree->Branch("V1730_wave4",&V1730_wave4,"V1730_wave4[num_points][140]/D");
+    //tree->Branch("V1730_wave5",&V1730_wave5,"V1730_wave5[num_points][140]/D");
     //tree->Branch("V1730_wave0",&V1730_wave0,"V1730_wave0[num_points]/D"); //think of eqn*
     //tree->Branch("V1730_wave1",&V1730_wave1,"V1730_wave1[num_points]/D"); //think of eqn*
     //tree->Branch("V1730_wave2",&V1730_wave2,"V1730_wave2[num_points]/D"); //think of eqn*
@@ -380,17 +382,18 @@ class ScanToTreeConverter: public TRootanaEventLoop {
 
             //std::cout <<measurements[i].GetNSamples() << " samples "<<std::endl; 
             
-            for(int ib = timeStart; ib < measurements[i].GetNSamples() && ib  < num_v1730_max + timeStart ; ib++){
+            for(int ib = 0; ib < measurements[i].GetNSamples() && ib  < num_v1730_max; ib++){
               
               //std::cout<<"ib = " <<ib <<std::endl;
 
               //0-89 and 2-40 being moved back by 20
 
-              if(chan == 0) V1730_wave0[num_points-1][ib-timeStart] = measurements[i].GetSample(ib);
-              if(chan == 1) V1730_wave1[num_points-1][ib-timeStart] = measurements[i].GetSample(ib);
-              if(chan == 2) V1730_wave2[num_points-1][ib-timeStart] = measurements[i].GetSample(ib);
-              //if(chan == 3) V1730_wave3[num_points-1][ib-timeStart] = measurements[i].GetSample(ib-60); 
-             // if(chan == 5) V1730_wave5[num_points-1][ib-timeStart] = measurements[i].GetSample(ib-60); 
+              if(chan == 0) V1730_wave0[num_points-1][ib] = measurements[i].GetSample(ib+timeStart);
+              if(chan == 1) V1730_wave1[num_points-1][ib] = measurements[i].GetSample(ib);
+              if(chan == 2) V1730_wave2[num_points-1][ib] = measurements[i].GetSample(ib+timeStart);
+              //if(chan == 3) V1730_wave3[num_points-1][ib] = measurements[i].GetSample(ib);
+              //if(chan == 4) V1730_wave4[num_points-1][ib] = measurements[i].GetSample(ib); 
+              //if(chan == 5) V1730_wave5[num_points-1][ib] = measurements[i].GetSample(ib); 
             }		             	      
           }
         }else{

--- a/midas2root/midas2root_ptf.cxx
+++ b/midas2root/midas2root_ptf.cxx
@@ -14,7 +14,10 @@
 #include <TTree.h>
 #include <TFile.h>
 
-const int nPoints_max = 6000; // 24000*100;
+
+constexpr bool single_point = true; // set to true for non-scans. This makes it accept everything! 
+constexpr int nPoints_max = single_point ? 1800*1600 : 6000; // if single_point, we do an hour. otherwise, like 4 seconds of data
+
 const int num_phidg_max = 10000;
 const int max_temp_sensor = 20;
 const int num_v1730_max = 140; // IMPOTANT: IF THIS IS EVER CHANGED, ALSO CHANGE THE HARDCODED VALUES FOR WAVEFORM BRANCH WIDTHS AS WELL (see: "v1730 data")
@@ -26,7 +29,6 @@ const int Ch_Offset = 1;
 
 // Flag to indicate the gantry was not moving and to record ADC and Phidget values. 
 bool gbl_accept_banks = false; //set FALSE
-bool single_point = false; // set to true for non-scans. This makes it accept everything! 
 int run_numb = 0;
 
 class ScanToTreeConverter: public TRootanaEventLoop {

--- a/midas2root/midas2root_ptf.cxx
+++ b/midas2root/midas2root_ptf.cxx
@@ -14,17 +14,15 @@
 #include <TTree.h>
 #include <TFile.h>
 
-#define TRUE 1
-#define FALSE 0
-
-#define nPoints_max 6000 // John 2019-11-05 Reduced from 1000000
-#define num_phidg_max 10000
-#define max_temp_sensor 20
-#define num_v1730_max 140 // IMPOTANT: IF THIS IS EVER CHANGED, ALSO CHANGE THE HARDCODED VALUES FOR WAVEFORM BRANCH WIDTHS AS WELL (see: "v1730 data")
-#define timeStart 110 // defines start of PMT Pulse timing window, currently at the 130th sample of 200, with a window size of 400 samples.
+const int nPoints_max = 6000;
+const int num_phidg_max = 10000;
+const int max_temp_sensor = 20;
+const int num_v1730_max = 140; // IMPOTANT: IF THIS IS EVER CHANGED, ALSO CHANGE THE HARDCODED VALUES FOR WAVEFORM BRANCH WIDTHS AS WELL (see: "v1730 data")
+const int timeStart = 110; // defines start of PMT Pulse timing window, currently at the 130th sample of 200, with a window size of 400 samples.
 
 // Offset for the ADC channel number
-#define Ch_Offset 1
+const int Ch_Offset = 1;
+
 
 // Flag to indicate the gantry was not moving and to record ADC and Phidget values. 
 bool gbl_accept_banks = false; //set FALSE

--- a/midas2root/midas2root_ptf.cxx
+++ b/midas2root/midas2root_ptf.cxx
@@ -14,7 +14,7 @@
 #include <TTree.h>
 #include <TFile.h>
 
-const int nPoints_max = 6000;
+const int nPoints_max = 6000; // 24000*100;
 const int num_phidg_max = 10000;
 const int max_temp_sensor = 20;
 const int num_v1730_max = 140; // IMPOTANT: IF THIS IS EVER CHANGED, ALSO CHANGE THE HARDCODED VALUES FOR WAVEFORM BRANCH WIDTHS AS WELL (see: "v1730 data")
@@ -26,7 +26,7 @@ const int Ch_Offset = 1;
 
 // Flag to indicate the gantry was not moving and to record ADC and Phidget values. 
 bool gbl_accept_banks = false; //set FALSE
-bool single_point = true; // set to true for non-scans. This makes it accept everything! 
+bool single_point = false; // set to true for non-scans. This makes it accept everything! 
 int run_numb = 0;
 
 class ScanToTreeConverter: public TRootanaEventLoop {
@@ -95,7 +95,7 @@ class ScanToTreeConverter: public TRootanaEventLoop {
   
   // V1730 waveforms
   // 9.Nov.2017 Let's try adding using channels 2,3,4, 5
-  double V1730_wave0[nPoints_max][num_v1730_max],  V1730_wave1[nPoints_max][num_v1730_max],  V1730_wave2[nPoints_max][num_v1730_max], V1730_wave3[nPoints_max][num_v1730_max], V1730_wave4[nPoints_max][num_v1730_max], V1730_wave5[nPoints_max][num_v1730_max];
+  double V1730_wave0[nPoints_max][num_v1730_max],V1730_wave1[nPoints_max][num_v1730_max], V1730_wave2[nPoints_max][num_v1730_max];
 
   // Add a timestamp for each event. TL 2022-02-25 
   double evt_timestamp[nPoints_max];
@@ -160,7 +160,7 @@ class ScanToTreeConverter: public TRootanaEventLoop {
 
     // v1730 data  V1730_wave0[nPoints_max][num_v1730_max]
     tree->Branch("V1730_wave0",&V1730_wave0,"V1730_wave0[num_points][140]/D"); //think of eqn* // SIZE OF COLUMN MUST MATCH num_v1730_max OR ELSE BANDING ISSUES WILL OCCUR
-    //tree->Branch("V1730_wave1",&V1730_wave1,"V1730_wave1[num_points][400]/D"); //think of eqn*
+    tree->Branch("V1730_wave1",&V1730_wave1,"V1730_wave1[num_points][400]/D"); //think of eqn*
     tree->Branch("V1730_wave2",&V1730_wave2,"V1730_wave2[num_points][140]/D"); //think of eqn*
     //tree->Branch("V1730_wave3",&V1730_wave3,"V1730_wave3[num_points][400]/D"); 
     //tree->Branch("V1730_wave4",&V1730_wave4,"V1730_wave4[num_points][400]/D");
@@ -293,6 +293,9 @@ class ScanToTreeConverter: public TRootanaEventLoop {
 
     std::cout << "Good TDC banks: " << ngoodTDCbanks << std::endl;;
     std::cout << "Bad  TDC banks: " << nbadTDCbanks << std::endl;;
+    if (single_point){
+      tree->Fill();
+    }
   }
 
   bool ProcessMidasEvent(TDataContainer& dataContainer){
@@ -381,9 +384,9 @@ class ScanToTreeConverter: public TRootanaEventLoop {
 
               //0-89 and 2-40 being moved back by 20
 
-              if(chan == 0) V1730_wave0[num_points-1][ib-timeStart] = measurements[i].GetSample(ib+69);
-              //if(chan == 1) V1730_wave1[num_points-1][ib-timeStart] = measurements[i].GetSample(ib-timeStart); // -130 is the timeStart offset, meaning the reference signal window starts at the start of the digitizer readout
-              if(chan == 2) V1730_wave2[num_points-1][ib-timeStart] = measurements[i].GetSample(ib+20);
+              if(chan == 0) V1730_wave0[num_points-1][ib-timeStart] = measurements[i].GetSample(ib);
+              if(chan == 1) V1730_wave1[num_points-1][ib-timeStart] = measurements[i].GetSample(ib);
+              if(chan == 2) V1730_wave2[num_points-1][ib-timeStart] = measurements[i].GetSample(ib);
               //if(chan == 3) V1730_wave3[num_points-1][ib-timeStart] = measurements[i].GetSample(ib-60); 
              // if(chan == 5) V1730_wave5[num_points-1][ib-timeStart] = measurements[i].GetSample(ib-60); 
             }		             	      

--- a/midas2root/reprocess_data.sh
+++ b/midas2root/reprocess_data.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+cd /home/midptf/online/data/
+
+reproc=(5630 5633 5645 5646 5647 5650 5651 5652 5653 5654)
+# reproc=(5645 5646 5647)
+for run in ${reproc[@]}; do
+    ./run_convert_to_root.sh $run
+done

--- a/midas2root/run_convert_to_root.sh
+++ b/midas2root/run_convert_to_root.sh
@@ -33,7 +33,7 @@ do
     
 
 
-  $cmd $ifile $RETVAL
+  $cmd $ifile $RETVAL $1
   RETVAL="$?"
   echo "moving output000${strRun}.root to tmp${basename}.root" 
   mv output000${strRun}.root tmp_${basename}.root

--- a/midas2root/run_convert_to_root.sh
+++ b/midas2root/run_convert_to_root.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Convert and merge root output
+# Usage: ./run_convert_to_root.sh [run #]
+
+# cmd=/home/midptf/online/ptf-online-converter/midas2root_WORKING/midas2root_ptf.exe
+cmd=/home/midptf/online/converter_clean/midas2root/midas2root_ptf.exe
+
+iRun=$1
+strRun=$(printf "%05d" $iRun)
+echo "Producing root output for Run${strRun}..."
+
+cwdir=`pwd`
+
+outdir=$cwdir
+#outdir=/home/midptf/packages/rootana/libAnalyzer
+
+tmpdir=$outdir/tmp_conv_`date '+%s'`
+mkdir $tmpdir
+cd $tmpdir
+
+echo "moved to ${PWD}"
+export RETVAL='0'
+
+for ifile in $( ls ~/online/data/run${strRun}sub???.mid.gz )
+do
+
+  filename=${ifile##*/}
+  basename=${filename%.*}
+
+  echo "Filename:" $filename
+  echo "Basename:" $basename
+    
+
+
+  $cmd $ifile $RETVAL
+  RETVAL="$?"
+  echo "moving output000${strRun}.root to tmp${basename}.root" 
+  mv output000${strRun}.root tmp_${basename}.root
+
+done
+
+outname=out_run${strRun}.root
+
+hadd -f $outdir/${outname} tmp_*.root
+
+cd $cwdir
+rm -r $tmpdir

--- a/rootana/libAnalyzer/TRootanaEventLoop.cxx
+++ b/rootana/libAnalyzer/TRootanaEventLoop.cxx
@@ -307,8 +307,9 @@ int TRootanaEventLoop::ProcessMidasFile(TApplication*app,const char*fname)
   while (1)
     {
       TMidasEvent event;
-      if (!f.Read(&event))
-	break;
+      if (!f.Read(&event)){
+	      break;
+      }
       
       /// Treat the begin run and end run events differently.
       int eventId = event.GetEventId();


### PR DESCRIPTION
I want to pull these changes into the main branch so they don't wind up permanently living in this working branch.
A more robust set of fixes would certainly be better, but given the main branch doesn't work right now, I consider this a step in the right direction! 

# Fixes 

## Segfault when loading midas files after the first

**The Problem:** originally, the TTree was only made when a "run start" midas event was processed. 
As a consequence, in files after the first, the TTree would never be made. 
And so when the fill command was called we'd get a segfault.

**The Fix:** now we now explicitly make the TTree if it's a null pointer.
The run number is now also provided to the executable by included bash script as an argument to `midas2root_ptf`. 

## Lost bank status

**The Problem:** the midas2root event stream is interrupted at the end of a file and resumed at the next one. 
`Midas2root_ptf` processes each file's event stream individually, after processing all files it then concatenates the individual files' root files into one big root file. 
`Midas2root_ptf` can, upon starting to process a file's event stream, default to either *accept* or *reject* events (essentially this is assuming the gantry is starting *stationary* or *mid-move*). This default depends on whether `gbl_accept_banks` is instantiated as `true` or `false`. 

Either assumption cannot be accurate in all cases. 
If it defaults to accept, when midas switches between files mid-move then some scanpoint will end up with an excessive number of noisy non-sense waveforms. 
If it instead defaults to reject, then when midas switches between files mid-scan then that scanpoint will be interrupted. 

**The Fix:** now, when `midas2root_ptf` reaches the end of a file, the acceptance status is returned by the `main` method. The controlling bash script records this return value, and then passes it on as an argument to the next `midas2root_ptf` instance. 

## Possible Better Fixes
The current fix is hacky and leads to midas2root searching for files with names consistent with the run number and the rank status.
So if, for instance, your run number is "5660" and you have a file named "5660", this will lead to unexpected behavior and almost certainly a crash. 

I don't know how easy this would be to implement, but there certainly are more robust fixes possible.
But if midas could include a header event for each new file including the run number (like a "continuing run event," that would be tremendously helpful. 
If these header events could include more meta-information, that would be event better.

An alternative, probably better fix, would be if the midas2root_ptf script were fundamentally modified to process a series of files as a single event stream. 
This functionality *does* appear to be in the event stream code, but it isn't incorporated.

# Other Changes

 - the make file now uses optimization. Earlier both the debugging flag and an optimization flag were provided; I think it gives preference towards debugging. 
 - slight change to the midas library path. This might effect some machines, but this code will only ever really be ran on the midptf01 DAQ PC. 
 - the timing window is wider now (140 samples vs 70)
 - Made swapping between single point measurements and scans easier (just changing a single and recompiling).
 - included the bash script we use to work with `midas2root_ptf` 

# Notes

These problems likely both exist in the `midas2root_mpmt` code! 
As I understand though, those scans never save more than 1Gb, and so never store multiple files.
Because of this, these bugs will not be encountered. 